### PR TITLE
fix(inputs.procstat): use correct values of disk_read_bytes, disk_write_bytes

### DIFF
--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -112,8 +112,8 @@ func (p *proc) metrics(prefix string, cfg *collectionConfig, t time.Time) ([]tel
 	if rc, wc, err := collectTotalReadWrite(p); err == nil {
 		fields[prefix+"read_bytes"] = rc
 		fields[prefix+"write_bytes"] = wc
-		fields[prefix+"disk_read_bytes"] = io.ReadBytes
-		fields[prefix+"disk_write_bytes"] = io.WriteBytes
+		fields[prefix+"disk_read_bytes"] = io.DiskReadBytes
+		fields[prefix+"disk_write_bytes"] = io.DiskWriteBytes
 	}
 
 	createdAt, err := p.CreateTime() // returns epoch in ms


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
